### PR TITLE
fix: count exec

### DIFF
--- a/qb/qcount/count_exec.go
+++ b/qb/qcount/count_exec.go
@@ -18,7 +18,7 @@ func (cq *Query) Exec() (int64, error) {
 		return 0, err
 	}
 
-	return 0, nil
+	return count, nil
 }
 
 func (cq *Query) build() string {


### PR DESCRIPTION
El Count estaba devolviendo siempre `0` en vez del `count` real.