### PR TITLE
Feat/allow filtering

### DIFF
--- a/qb/qcount/count.go
+++ b/qb/qcount/count.go
@@ -7,11 +7,12 @@ import (
 
 // Query create new select count query
 type Query struct {
-	ctx    query.Query
-	table  string
-	column string
-	where  []query.WhereStm
-	args   []interface{}
+	ctx            query.Query
+	table          string
+	column         string
+	where          []query.WhereStm
+	allowFiltering bool
+	args           []interface{}
 }
 
 // New create a new count query instance by passing a cassandra session
@@ -32,6 +33,12 @@ func (cq *Query) Column(c string) *Query {
 // From set table for count query
 func (cq *Query) From(t string) *Query {
 	cq.table = t
+	return cq
+}
+
+// AllowFiltering sets a ALLOW FILTERING clause on the query.
+func (cq *Query) AllowFiltering() *Query {
+	cq.allowFiltering = true
 	return cq
 }
 

--- a/qb/qcount/count_exec.go
+++ b/qb/qcount/count_exec.go
@@ -28,6 +28,10 @@ func (cq *Query) build() string {
 		q = q.Where(query.BuildWhere(cq.where)...)
 	}
 
+	if cq.allowFiltering {
+		q = q.AllowFiltering()
+	}
+
 	queryStr, _ := q.ToCql()
 
 	if cq.ctx.Debug {

--- a/qb/qselect/build.go
+++ b/qb/qselect/build.go
@@ -22,6 +22,10 @@ func (q *Query) build() string {
 		sb = sb.Limit(q.limit)
 	}
 
+	if q.allowFiltering {
+		sb = sb.AllowFiltering()
+	}
+
 	if len(q.orderBy) > 0 {
 		for _, column := range q.orderBy {
 			var order qb.Order = qb.DESC

--- a/qb/qselect/select.go
+++ b/qb/qselect/select.go
@@ -7,16 +7,17 @@ import (
 
 // Query represents a cassandra select statement and his options
 type Query struct {
-	ctx     query.Query
-	fields  query.Columns
-	args    []interface{}
-	table   string
-	bind    interface{}
-	where   []query.WhereStm
-	groupBy query.Columns
-	orderBy query.Columns
-	order   query.Order
-	limit   uint
+	ctx            query.Query
+	fields         query.Columns
+	args           []interface{}
+	table          string
+	bind           interface{}
+	where          []query.WhereStm
+	groupBy        query.Columns
+	orderBy        query.Columns
+	order          query.Order
+	limit          uint
+	allowFiltering bool
 }
 
 // New create a new select query by passing a cassandra session and debug options
@@ -63,6 +64,12 @@ func (q *Query) GroupBy(f ...string) *Query {
 // Limit adds `limit` query statement
 func (q *Query) Limit(l uint) *Query {
 	q.limit = l
+	return q
+}
+
+// AllowFiltering sets a ALLOW FILTERING clause on the query.
+func (q *Query) AllowFiltering() *Query {
+	q.allowFiltering = true
 	return q
 }
 


### PR DESCRIPTION
# Description
Se agrega la opción de agregarle `Allow Filtering` a la query de cassandra. La idea es utilizarlo lo minimo posible.

Un ejemplo de uso sería en la tabla `provider_events_control` que tiene las columnas `game_id, version y processed` siendo `game_id y version` las primary keys.
Tenemos que consultar por los registros de esa tabla con cierto `game_id, version y processed = false`.